### PR TITLE
Fix black navbar in sub pages

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "themes/capsule"]
 	path = themes/capsule
-	url = https://github.com/sudorook/capsule
+	url = https://github.com/PasscodeFR/capsule
 [submodule "themes/next"]
 	path = themes/next
 	url = https://github.com/xtfly/hugo-theme-next


### PR DESCRIPTION
- change `themes/capsule` submodule repo to `PasscodeFR/capsule`
- Fix black navbar in sub pages